### PR TITLE
メール送信機能追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ build-iPhoneSimulator/
 /lib/bundler/man/
 
 .idea
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'jquery-rails'
 
 gem 'slim-rails'
 gem 'devise'
-gem 'letter_opener_web'
 gem 'dotenv-rails'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'jquery-rails'
 gem 'slim-rails'
 gem 'devise'
 gem 'letter_opener_web'
+gem 'dotenv-rails'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'jquery-rails'
 
 gem 'slim-rails'
 gem 'devise'
+gem 'letter_opener_web'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,10 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
+    dotenv (2.4.0)
+    dotenv-rails (2.4.0)
+      dotenv (= 2.4.0)
+      railties (>= 3.2, < 6.0)
     erubi (1.7.1)
     execjs (2.7.0)
     ffi (1.9.23)
@@ -201,6 +205,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   jbuilder (~> 2.5)
   jquery-rails
   letter_opener_web

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     autoprefixer-rails (8.5.1)
       execjs
@@ -78,6 +80,14 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.6.0)
+      launchy (~> 2.2)
+    letter_opener_web (1.3.4)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -98,6 +108,7 @@ GEM
     orm_adapter (0.5.0)
     pg (0.21.0)
     popper_js (1.12.9)
+    public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
     rack-test (1.0.0)
@@ -192,6 +203,7 @@ DEPENDENCIES
   devise
   jbuilder (~> 2.5)
   jquery-rails
+  letter_opener_web
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
   puma (~> 3.7)

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -39,13 +39,10 @@ class InterviewsController < ApplicationController
         redirect_to user_interviews_url(current_user), success: 'updated'
       end
     else
-      if @interview.save
-        case interview_params[:status]
-          when 'approval'
-            interviews = Interview.where(user_id: @user.id).where.not(id: @interview.id)
-            interviews.update_all(status: 'dissmissed')
-            InterviewMailer.approval_date(@interview).deliver
-        end
+      if @interview.save && interview_params[:status] == 'approval'
+        interviews = Interview.where(user_id: @user.id).where.not(id: @interview.id)
+        interviews.update_all(status: 'dissmissed')
+        InterviewMailer.approval_date(@interview).deliver
         redirect_to user_interviews_url(@user), success: 'updated!'
       else
         flash.now[:danger] = @interview.errors.full_messages

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -18,6 +18,7 @@ class InterviewsController < ApplicationController
     @interview.user_id = current_user.id
     @interview.status = :pending
     if @interview.save
+      InterviewMailer.require_decide_date(interview_params, current_user).deliver
       redirect_to user_interview_url(current_user, @interview), success: 'created!'
     else
       render :new
@@ -38,13 +39,15 @@ class InterviewsController < ApplicationController
         redirect_to user_interviews_url(current_user), success: 'updated'
       end
     else
-      case interview_params[:status]
-      when 'approval'
-        interviews = Interview.where(user_id: @user.id).where.not(id: @interview.id)
-        interviews.update_all(status: 'dissmissed')
-      when 'dissmissed'
-      end
       if @interview.save
+        case interview_params[:status]
+          when 'approval'
+            interviews = Interview.where(user_id: @user.id).where.not(id: @interview.id)
+            interviews.update_all(status: 'dissmissed')
+            InterviewMailer.approval_date(@interview).deliver
+          when 'dissmissed'
+            InterviewMailer.dissmiss_date(@interview).deliver
+        end
         redirect_to user_interviews_url(@user), success: 'updated!'
       else
         flash.now[:danger] = @interview.errors.full_messages
@@ -61,7 +64,7 @@ class InterviewsController < ApplicationController
   private
 
   def interview_params
-    params.require(:interview).permit(:date, :status)
+    params.require(:interview).permit(:date, :status, :interviewer_id)
   end
 
   def set_user

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -45,8 +45,6 @@ class InterviewsController < ApplicationController
             interviews = Interview.where(user_id: @user.id).where.not(id: @interview.id)
             interviews.update_all(status: 'dissmissed')
             InterviewMailer.approval_date(@interview).deliver
-          when 'dissmissed'
-            InterviewMailer.dissmiss_date(@interview).deliver
         end
         redirect_to user_interviews_url(@user), success: 'updated!'
       else

--- a/app/mailers/interview_mailer.rb
+++ b/app/mailers/interview_mailer.rb
@@ -1,0 +1,18 @@
+class InterviewMailer < ApplicationMailer
+
+  def require_decide_date(interview_params, current_user)
+    @interviewer = User.find(interview_params[:interviewer_id])
+    @user = current_user
+    mail(to: @interviewer.email, cc: current_user.email, subject: '面談の日程の')
+  end
+
+  def approval_date(interview)
+    @interview = interview
+    @user = @interview.user
+    mail(to: @user.email, subject: '面談日程が決定しました')
+  end
+
+  def dissmiss_date(user)
+  
+  end
+end

--- a/app/mailers/interview_mailer.rb
+++ b/app/mailers/interview_mailer.rb
@@ -3,16 +3,12 @@ class InterviewMailer < ApplicationMailer
   def require_decide_date(interview_params, current_user)
     @interviewer = User.find(interview_params[:interviewer_id])
     @user = current_user
-    mail(to: @interviewer.email, cc: current_user.email, subject: '面談の日程の')
+    mail(to: @interviewer.email, cc: current_user.email, subject: '面談日程が申請されました')
   end
 
   def approval_date(interview)
     @interview = interview
     @user = @interview.user
     mail(to: @user.email, subject: '面談日程が決定しました')
-  end
-
-  def dissmiss_date(user)
-  
   end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -3,5 +3,7 @@ class Interview < ApplicationRecord
 
   enum status: {dissmissed: 0, approval: 1, pending: 2}
 
+  attr_accessor :interviewer_id
+
   validates :date, presence: true, is_later_now: true
 end

--- a/app/views/interview_mailer/approval_date.text.erb
+++ b/app/views/interview_mailer/approval_date.text.erb
@@ -1,0 +1,2 @@
+<%= @user.name %> さんの面接日が
+<%= @interview.date %>に決定しました．

--- a/app/views/interview_mailer/require_decide_date.text.erb
+++ b/app/views/interview_mailer/require_decide_date.text.erb
@@ -1,0 +1,8 @@
+<%= @interviewer.name %>さん
+
+<%= @user.name %>様が
+
+面接日程を申請されました．
+下記にアクセスし．承認．拒否の判定を行ってください．
+
+<%= user_interviews_url(@user) %>

--- a/app/views/interviews/_form.html.slim
+++ b/app/views/interviews/_form.html.slim
@@ -1,3 +1,5 @@
 h1 面接時間指定
+= f.label '指定するユーザ'
+= f.collection_select :interviewer_id, User.where.not(id: current_user.id), :id, :name, { include_blank: true }, class: 'form-control'
 = f.label :date, class: 'col-2 col-form-label sr-only'
 = f.datetime_select :date, {use_month_names: %w(1月 2月 3月 4月 5月 6月 7月 8月 9月 10月 11月 12月), start_year: Time.zone.now.year, default: Time.zone.now}, {class: 'form-control', style: 'display: inline-block; width: auto;'}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,9 +31,20 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: 'localhost:3001' }
 
-  config.action_mailer.delivery_method = :letter_opener_web
+  #config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings =
+    {
+      user_name: ENV['MAILER_ID'],
+      password: ENV['MAILER_PASSWORD'],
+      password: ENV['MAILER_APP_PASSWORD'],
+      domain: 'example.com',
+      address: 'smtp.gmail.com',
+      port: 587,
+      authentication: :plain,
+    }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,11 +27,13 @@ Rails.application.configure do
   end
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
+
+  config.action_mailer.delivery_method = :letter_opener_web
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,6 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: 'localhost:3001' }
 
-  #config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings =
     {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,19 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  #
+  config.action_mailer.default_url_options = { host: 'e-navigator-toshichanapp.herokuapp.com' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings =
+    {
+      user_name: ENV['MAILER_ID'],
+      password: ENV['MAILER_PASSWORD'],
+      password: ENV['MAILER_APP_PASSWORD'],
+      domain: 'example.com',
+      address: 'smtp.gmail.com',
+      port: 587,
+      authentication: :plain,
+    }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
     root to: "devise/sessions#new"
   end
 
+  mount LetterOpenerWeb::Engine, at: "/letter_opener"
+
   resources :users do
     resources :interviews
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,6 @@ Rails.application.routes.draw do
     root to: "devise/sessions#new"
   end
 
-  mount LetterOpenerWeb::Engine, at: "/letter_opener"
-
   resources :users do
     resources :interviews
   end


### PR DESCRIPTION
### やりたかったこと
- 第３章　面談日程を知らせるためのメール送信機能

### やったこと
- メーラーの作成
- letter_opener_webの導入
- smtpメール送信


### 動作確認方法
- [ ] [https://e-navigator-toshichanapp.herokuapp.com/](https://e-navigator-toshichanapp.herokuapp.com/)にアクセス
- [ ] 存在するメールアドレスでアカウントを用意する
- [ ] 上とは別のアカウントでログインする
- [ ] 自分の面接一覧　→ 面接予約をクリック
- [ ] 存在するメールアドレスアカウントユーザを指定し，面接予約をする
- [ ] 存在するメールアドレスアカウントユーザでログイン
- [ ] メールに記載されているurlをクリックする
- [ ] 承認する
- [ ] メールを確認する
